### PR TITLE
iosで動画が自動的に拡大される問題の解消

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -29,7 +29,7 @@ const { pageName } = Astro.props;
 			<li><a class="text-20" href="/results#contents-tournament">試合結果</a></li>
 		</ul>
     <div class="videowrap">
-     <video id="menuVideo" muted src="/menuanime.mp4"></video>
+     <video id="menuVideo" playsinline muted src="/menuanime.mp4"></video>
     </div>
 		<ul class="barbottom">
 			<li>©WEB製作研究部</li>


### PR DESCRIPTION
<!-- ⚠️#[Issue num] [prefex]: title -->
<!-- #1 feat: first commit -->

<!-- なお記入しない項目は削除せず、そのまま放置すること -->
## レビュー優先度

- [x] 🚀 今すぐ確認してほしい
- [ ] 🚗 今日中に確認してほしい
- [ ] 🏃 3日以内に確認してほしい
- [ ] 🐢 5日以内までに確認してほしい

## レビュー深さ

- [ ] 🕵️ 該当Issueから考慮してレビューしてほしい
- [ ] 🧪 ローカルで動作確認してほしい
- [ ] 🔍 コードロジックを理解して確認してほしい
- [ ] 👀 ぱっと確認するだけで良い

## 関連Issue
<!-- 例:
- #10
- #20
- #30
 -->

- ここに書く

## 概要（ざっくり）
<!-- このプルリクエストが解決する課題や目標を記述 -->
- iosで動画を表示する際に自動で全画面になってしまう問題を解決するため、videoタグにplaysinline属性を追加しました。

## ユーザー側の変更内容
<!-- このプルリクエストで追加・削除した機能・ユーザーへの報告事項について記述 -->
- ここに書く

## コードの変更内容
<!-- このプルリクエストで行った変更内容や影響範囲を記述 -->
- ここに書く

## スクリーンショット（可能であれば）

ここに書く

## レビューに必要な情報
<!-- レビュアーに伝えたい情報や注意点を記述 -->
- ここに書く
